### PR TITLE
Collectd cloudwatch v1.0.6

### DIFF
--- a/collectd-cloudwatch-container.service
+++ b/collectd-cloudwatch-container.service
@@ -19,6 +19,7 @@ ExecStart=/bin/sh -c '\
   /usr/bin/docker run --rm --name %p_$(uuidgen) \
   --env "NAMESPACE=com.ft.up.$(/usr/bin/etcdctl get /ft/config/environment_tag).neo4j" \
   -v /proc:/host/proc \
+  -v /vol/neo4j:/vol/neo4j \
   $IMAGENAME:$DOCKER_APP_VERSION'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=^/%p_)"'

--- a/services.yaml
+++ b/services.yaml
@@ -21,4 +21,4 @@ services:
 - name: alb-dns-registrator.service
   version: v1.0.0
 - name: collectd-cloudwatch-container.service
-  version: v1.0.4
+  version: v1.0.5

--- a/services.yaml
+++ b/services.yaml
@@ -21,4 +21,4 @@ services:
 - name: alb-dns-registrator.service
   version: v1.0.0
 - name: collectd-cloudwatch-container.service
-  version: v1.0.3
+  version: v1.0.4

--- a/services.yaml
+++ b/services.yaml
@@ -21,4 +21,4 @@ services:
 - name: alb-dns-registrator.service
   version: v1.0.0
 - name: collectd-cloudwatch-container.service
-  version: v1.0.5
+  version: v1.0.6


### PR DESCRIPTION
collectd-cloudwatch-container v1.0.6 reduces the number of metrics sent to cloudwatch. 
Metrics are...
1. Memory used (bytes)
2. Load Average
3. Root partition disk usage
4. /vol/neo4j disk usage